### PR TITLE
fix to error of line 60 that happen when archive_dir tree path doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Currently supported lists;
 
 ## Requirements
 * Perl
-* Array::Utils (install via `sudo perl -MCPAN -e 'install Array::Utils'`)
+* Array::Utils (install via `sudo perl -MCPAN -e 'install Array::Utils'` aslo you may needed to use `export PERL5LIB=` after installing Array::Utils to add path to the library)
 
 ## Installation
 1. SSH to deployed pi-hole

--- a/create_blocklist_porn.pl
+++ b/create_blocklist_porn.pl
@@ -14,6 +14,8 @@ use Array::Utils qw(:all);
 use File::Copy;
 use File::Fetch;
 use File::Slurp;
+use File::Basename;
+use File::Path qw/make_path/;
 use LWP::Simple;
 use POSIX qw(strftime);
 
@@ -57,7 +59,9 @@ foreach ($url1, $url2) {
 
 # create dir for archive files
 unless ( -d "$archive_dir" ) {
-    mkdir "$archive_dir",0755 or die $!;
+    my $dir = dirname($archive_dir);
+    make_path($dir);
+    open my $fh, '>', $archive_dir or die "Ouch: $!\n";
 }
 
 print "extracting files\n";


### PR DESCRIPTION
Peace,

first thanks, when i tried to run the program, it through an error `No such file or directory at ./create_blocklist_porn.pl line 60, it appear that `mkdir` only create the last directory on the `archive_dir` path, i tried to make this change to fix that, also as i don't use perl, after installing the lib using `sudo perl  -MCPAN ...`, it installed properly, but when i tried to run the program, it through an error about `Array::Utils`, it appear that i needed to use `export  PERL5LIB=`m, that is way i added those line to the `README.md` file